### PR TITLE
Fix data and remove deprecated views variable

### DIFF
--- a/nekobin/types.py
+++ b/nekobin/types.py
@@ -22,7 +22,11 @@ class Neko(NekoFy):
         self.raw = "https://nekobin.com/raw/" + result["key"]
         self.title = result["title"]
         self.author = result["author"]
-        self.date = datetime.fromtimestamp(result["date"])
-        self.views = result["views"]
+        self.date = self.format_date(result["date"])
         self.length = result["length"]
         self.content = result["content"]
+
+    def format_date(self, date: str):
+        dt_obj = datetime.strptime(date, '%Y-%m-%dT%H:%M:%S.%fZ')
+        py_timestamp = dt_obj.timestamp()
+        return datetime.fromtimestamp(py_timestamp)


### PR DESCRIPTION
Now NekoBin returns obj like this:

result: {     'author': None,
		 'content': 'Hello World',
		 'date': '2023-05-08T07:47:35.367506Z',
		 'key': 'yociwehoso',
		 'length': 11,
		 'title': None
           }
         
* No Views priveded
* Date get as string, what returns error with prev processing.

Finaly we get:
neko: <Neko: 
{
'success': True, 
'key': 'yociwehoso', 
'url': 'https://nekobin.com/yociwehoso', 
'raw': 'https://nekobin.com/raw/yociwehoso',
'title': None, 'author': None, 
'date': datetime.datetime(2023, 5, 8, 7, 47, 35, 367506),  'length': 11, 
'content': 'Hello World'
}>